### PR TITLE
Set json library version to the one Starsector (probably) bundles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation group: 'org.lwjgl.lwjgl', name: 'lwjgl', version: '2.9.3'
     implementation group: 'org.lwjgl.lwjgl', name: 'lwjgl_util', version: '2.9.3'
     implementation group: 'log4j', name: 'log4j', version: '1.2.9'
-    implementation group: 'org.json', name: 'json', version: '20170516'
+    implementation group: 'org.json', name: 'json', version: '20090211'
     implementation group: 'net.java.jinput', name: 'jinput', version: '2.0.7'
     implementation group: 'org.codehaus.janino', name: 'janino', version: '3.0.7'
 


### PR DESCRIPTION
Using the wrong one can lead to odd errors at runtime due to missing
methods. In particular, it seems that the bundled version doesn't have
`JSONObject.keySet`. The exact version is still somewhat of a mystery,
but it's definitely something earlier than 2013 - 2013+ have `keySet`.
The files in the bundled `json.jar` are timestamped with 9th of May,
2010, so 2009 seems like a reasonable guess.